### PR TITLE
Abstract out group id into a config option

### DIFF
--- a/config/app.cfg
+++ b/config/app.cfg
@@ -31,6 +31,9 @@ gitlab_project_ids = {
     "logs": "248",
 }
 
+# The gitlab group name that Rubberband users will belong to
+gitlab_group_name = "integer"
+
 # SMTP connection info. Learn more about using Google's SMTP service here:
 # https://support.google.com/a/answer/176600?hl=en
 smtp_host = "smtp.gmail.com"

--- a/rubberband/boilerplate.py
+++ b/rubberband/boilerplate.py
@@ -29,6 +29,11 @@ define(
 )
 
 define(
+    "gitlab_group_name",
+    default="integer",
+    help="The Gitlab group name that Rubberband users belong to.",
+)
+define(
     "gitlab_private_token",
     default="",
     help="Private token for gitlab user that Rubberband will make requests as.",

--- a/rubberband/utils/gitlab.py
+++ b/rubberband/utils/gitlab.py
@@ -44,11 +44,13 @@ def get_user_access_level(user_mail):
         integer corresponding to gitlab access level (0: no, < 15: read, > 15: write, > 45: delete)
     """
     client = Gitlab(options.gitlab_url, options.gitlab_private_token)
-    group_id = "integer"
-    group_users = client.groups.get(group_id).members.list(query=user_mail)
-    project_users = client.projects.get(
-        options.gitlab_project_ids["scip"]
-    ).members.list(query=user_mail)
+    group_users = client.groups.get(options.gitlab_group_name).members.list(
+        query=user_mail
+    )
+    principal_gitlab_project = next(iter(options.gitlab_project_ids.values()))
+    project_users = client.projects.get(principal_gitlab_project).members.list(
+        query=user_mail
+    )
     min_access = 20
     # so something is wrong, return 0
     if (len(group_users) > 1 or len(project_users) > 1) or (


### PR DESCRIPTION
Also, grab the first gitlab project in the projects dictionary to validate access.